### PR TITLE
Solve Eclipse problem "Dynamic Web Module 3.0 requires Java 1.6 or newer"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,17 @@
 	</dependencies>
 	<build>
 		<finalName>simple-oauth-consumer</finalName>
+	    <plugins>
+	       <plugin>
+	       <groupId>org.apache.maven.plugins</groupId>
+	       <artifactId>maven-compiler-plugin</artifactId>
+	       <version>3.1</version>
+	       <configuration>
+	           <source>1.7</source>
+	           <target>1.7</target>
+	       </configuration>
+	   </plugin>
+	   </plugins>
 	</build>
 	<properties>
 		<spring.version>4.0.1.RELEASE</spring.version>


### PR DESCRIPTION
This is solving the Eclipse problem "Dynamic Web Module 3.0 requires Java 1.6 or newer", when you import project to eclipse and want to run that inside Eclipse.
